### PR TITLE
Fix issue in which More is never set

### DIFF
--- a/pkg/server/list.go
+++ b/pkg/server/list.go
@@ -47,7 +47,7 @@ func (l *LimitedServer) list(ctx context.Context, r *etcdserverpb.RangeRequest) 
 		Kvs:    kvs,
 	}
 
-	if limit > 0 && resp.Count > limit {
+	if limit > 0 && resp.Count > r.Limit {
 		resp.More = true
 		resp.Kvs = kvs[0 : limit-1]
 	}


### PR DESCRIPTION
Due to checking the wrong variable More is never set to true. This
causes an issue specifically only when k8s does selector based lists
that are also paginated.