### PR TITLE
Stub-out sqlite drivers to build Kine without CGO

### DIFF
--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -1,3 +1,5 @@
+// +build cgo
+
 package sqlite
 
 import (

--- a/pkg/drivers/sqlite/sqlite_nocgo.go
+++ b/pkg/drivers/sqlite/sqlite_nocgo.go
@@ -1,0 +1,26 @@
+// +build !cgo
+
+package sqlite
+
+import (
+        "errors"
+	"database/sql"
+
+	"github.com/rancher/kine/pkg/drivers/generic"
+	"github.com/rancher/kine/pkg/server"
+
+)
+
+var errNoCgo = errors.New("this binary is built without CGO, sqlite is disabled")
+
+func New(dataSourceName string) (server.Backend, error) {
+        return nil, errNoCgo
+}
+
+func NewVariant(driverName, dataSourceName string) (server.Backend, *generic.Generic, error) {
+        return nil, nil, errNoCgo
+}
+
+func setup(db *sql.DB) error {
+        return errNoCgo
+}


### PR DESCRIPTION
Since SQLite depends on the C library and some Golang archs doesn't have CGO support, this PR adds a stub where Kine is generated but without SQlite support.