### PR TITLE
Adjust startKey on list start

### DIFF
--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -172,8 +172,16 @@ func (s *SQLLog) List(ctx context.Context, prefix, startKey string, limit, revis
 		err  error
 	)
 
+	// It's assumed that when there is a start key that that key exists.
 	if strings.HasSuffix(prefix, "/") {
+		// In the situation of a list start the startKey will not exist so set to ""
+		if prefix == startKey {
+			startKey = ""
+		}
 		prefix += "%"
+	} else {
+		// Also if this isn't a list there is no reason to pass startKey
+		startKey = ""
 	}
 
 	if revision == 0 {


### PR DESCRIPTION
 On list if revision != 0 and startKey != "" it is assumed that startKey exists.  If it doesn't exists nothing will be returned. If we are starting a new list at a revision then startKey will equal prefix and that key does not exists.  This change will set startKey to "" in this situaion so that list works.