### PR TITLE
Update function signature on nocgo stub

### DIFF
--- a/pkg/drivers/sqlite/sqlite_nocgo.go
+++ b/pkg/drivers/sqlite/sqlite_nocgo.go
@@ -3,24 +3,24 @@
 package sqlite
 
 import (
-        "errors"
+	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/rancher/kine/pkg/drivers/generic"
 	"github.com/rancher/kine/pkg/server"
-
 )
 
 var errNoCgo = errors.New("this binary is built without CGO, sqlite is disabled")
 
-func New(dataSourceName string) (server.Backend, error) {
-        return nil, errNoCgo
+func New(ctx context.Context, dataSourceName string) (server.Backend, error) {
+	return nil, errNoCgo
 }
 
 func NewVariant(driverName, dataSourceName string) (server.Backend, *generic.Generic, error) {
-        return nil, nil, errNoCgo
+	return nil, nil, errNoCgo
 }
 
 func setup(db *sql.DB) error {
-        return errNoCgo
+	return errNoCgo
 }


### PR DESCRIPTION
Fix signature of `sqlite.New` function updated on https://github.com/rancher/kine/commit/c395d22fffc82863dccd39bb807a26bafd107b9d.