### PR TITLE
Add Dockerfile for building Kine in a container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.13.7-alpine3.11 AS builder
+RUN apk --no-cache add gcc musl-dev
+WORKDIR /go/src/github.com/rancher/kine
+COPY . .
+RUN GO111MODULE=on go build -o /bin/kine
+
+FROM alpine:3.11
+COPY --from=builder /bin/kine /bin/kine
+ENTRYPOINT ["/bin/kine"]


### PR DESCRIPTION
Such a container could be used as a sidecar container for any k8s api server (such as aggregated APIs).

Contributes to #26.

I picked alpine 3.11 as the base image to try to keep things tiny.