### PR TITLE
Make connection pooling adjustable

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"os"
-	"time"
 
 	"github.com/rancher/kine/pkg/endpoint"
 	"github.com/rancher/wrangler/pkg/signals"
@@ -57,7 +56,7 @@ func main() {
 			Name:        "datastore-connection-max-lifetime",
 			Usage:       "Maximum amount of time a connection may be reused. Defined as a parsable string, e.g., 1s, 2500ms, and 1h30m are all accepted values",
 			Destination: &config.ConnectionPoolConfig.MaxLifetime,
-			Value:       time.Second,
+			Value:       0,
 		},
 		cli.StringFlag{
 			Name:        "key-file",

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"os"
+	"time"
 
 	"github.com/rancher/kine/pkg/endpoint"
 	"github.com/rancher/wrangler/pkg/signals"
@@ -39,6 +40,24 @@ func main() {
 			Name:        "cert-file",
 			Usage:       "Certificate for DB connection",
 			Destination: &config.CertFile,
+		},
+		cli.IntFlag{
+			Name:        "datastore-max-idle-connections",
+			Usage:       "Maximum number of idle connections used by datastore. If num <= 0, then no connections are retained",
+			Destination: &config.ConnectionPoolConfig.MaxIdle,
+			Value:       2,
+		},
+		cli.IntFlag{
+			Name:        "datastore-max-open-connections",
+			Usage:       "Maximum number of idle connections used by datastore. If num <= 0, then there is no limit",
+			Destination: &config.ConnectionPoolConfig.MaxOpen,
+			Value:       0,
+		},
+		cli.DurationFlag{
+			Name:        "datastore-connection-max-lifetime",
+			Usage:       "Maximum duration a connection is held alive. Defined as a parsable string, e.g., 1s, 2500ms, and 1h30m are all accepted values",
+			Destination: &config.ConnectionPoolConfig.MaxLifetime,
+			Value:       time.Second,
 		},
 		cli.StringFlag{
 			Name:        "key-file",

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func main() {
 		},
 		cli.DurationFlag{
 			Name:        "datastore-connection-max-lifetime",
-			Usage:       "Maximum duration a connection is held alive. Defined as a parsable string, e.g., 1s, 2500ms, and 1h30m are all accepted values",
+			Usage:       "Maximum amount of time a connection may be reused. Defined as a parsable string, e.g., 1s, 2500ms, and 1h30m are all accepted values",
 			Destination: &config.ConnectionPoolConfig.MaxLifetime,
 			Value:       time.Second,
 		},

--- a/pkg/drivers/dqlite/dqlite.go
+++ b/pkg/drivers/dqlite/dqlite.go
@@ -15,6 +15,7 @@ import (
 	"github.com/canonical/go-dqlite/client"
 	"github.com/canonical/go-dqlite/driver"
 	"github.com/pkg/errors"
+	"github.com/rancher/kine/pkg/drivers/generic"
 	"github.com/rancher/kine/pkg/drivers/sqlite"
 	"github.com/rancher/kine/pkg/server"
 	"github.com/sirupsen/logrus"
@@ -66,7 +67,7 @@ outer:
 	return nil
 }
 
-func New(ctx context.Context, datasourceName string) (server.Backend, error) {
+func New(ctx context.Context, datasourceName string, connPoolConfig generic.ConnectionPoolConfig) (server.Backend, error) {
 	opts, err := parseOpts(datasourceName)
 	if err != nil {
 		return nil, err
@@ -95,7 +96,7 @@ func New(ctx context.Context, datasourceName string) (server.Backend, error) {
 	}
 
 	sql.Register("dqlite", d)
-	backend, generic, err := sqlite.NewVariant(ctx, "dqlite", opts.dsn)
+	backend, generic, err := sqlite.NewVariant(ctx, "dqlite", opts.dsn, connPoolConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "sqlite client")
 	}

--- a/pkg/drivers/dqlite/no_dqlite.go
+++ b/pkg/drivers/dqlite/no_dqlite.go
@@ -6,9 +6,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/rancher/kine/pkg/drivers/generic"
 	"github.com/rancher/kine/pkg/server"
 )
 
-func New(ctx context.Context, datasourceName string) (server.Backend, error) {
+func New(ctx context.Context, datasourceName string, connPoolConfig generic.ConnectionPoolConfig) (server.Backend, error) {
 	return nil, fmt.Errorf("dqlite is not support, compile with \"-tags dqlite\"")
 }

--- a/pkg/drivers/mysql/mysql.go
+++ b/pkg/drivers/mysql/mysql.go
@@ -40,7 +40,7 @@ var (
 	createDB    = "create database if not exists "
 )
 
-func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config) (server.Backend, error) {
+func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoolConfig generic.ConnectionPoolConfig) (server.Backend, error) {
 	tlsConfig, err := tlsInfo.ClientConfig()
 	if err != nil {
 		return nil, err
@@ -59,7 +59,7 @@ func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config) (server
 		return nil, err
 	}
 
-	dialect, err := generic.Open(ctx, "mysql", parsedDSN, "?", false)
+	dialect, err := generic.Open(ctx, "mysql", parsedDSN, connPoolConfig, "?", false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/drivers/pgsql/pgsql.go
+++ b/pkg/drivers/pgsql/pgsql.go
@@ -41,7 +41,7 @@ var (
 	createDB = "create database "
 )
 
-func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config) (server.Backend, error) {
+func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoolConfig generic.ConnectionPoolConfig) (server.Backend, error) {
 	parsedDSN, err := prepareDSN(dataSourceName, tlsInfo)
 	if err != nil {
 		return nil, err
@@ -51,7 +51,7 @@ func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config) (server
 		return nil, err
 	}
 
-	dialect, err := generic.Open(ctx, "postgres", parsedDSN, "$", true)
+	dialect, err := generic.Open(ctx, "postgres", parsedDSN, connPoolConfig, "$", true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -39,12 +39,12 @@ var (
 	}
 )
 
-func New(ctx context.Context, dataSourceName string) (server.Backend, error) {
-	backend, _, err := NewVariant(ctx, "sqlite3", dataSourceName)
+func New(ctx context.Context, dataSourceName string, connPoolConfig generic.ConnectionPoolConfig) (server.Backend, error) {
+	backend, _, err := NewVariant(ctx, "sqlite3", dataSourceName, connPoolConfig)
 	return backend, err
 }
 
-func NewVariant(ctx context.Context, driverName, dataSourceName string) (server.Backend, *generic.Generic, error) {
+func NewVariant(ctx context.Context, driverName, dataSourceName string, connPoolConfig generic.ConnectionPoolConfig) (server.Backend, *generic.Generic, error) {
 	if dataSourceName == "" {
 		if err := os.MkdirAll("./db", 0700); err != nil {
 			return nil, nil, err
@@ -52,7 +52,7 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string) (server.
 		dataSourceName = "./db/state.db?_journal=WAL&cache=shared"
 	}
 
-	dialect, err := generic.Open(ctx, driverName, dataSourceName, "?", false)
+	dialect, err := generic.Open(ctx, driverName, dataSourceName, connPoolConfig, "?", false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rancher/kine/pkg/drivers/dqlite"
+	"github.com/rancher/kine/pkg/drivers/generic"
 	"github.com/rancher/kine/pkg/drivers/mysql"
 	"github.com/rancher/kine/pkg/drivers/pgsql"
 	"github.com/rancher/kine/pkg/drivers/sqlite"
@@ -28,9 +29,10 @@ const (
 )
 
 type Config struct {
-	GRPCServer *grpc.Server
-	Listener   string
-	Endpoint   string
+	GRPCServer           *grpc.Server
+	Listener             string
+	Endpoint             string
+	ConnectionPoolConfig generic.ConnectionPoolConfig
 
 	tls.Config
 }
@@ -124,13 +126,13 @@ func getKineStorageBackend(ctx context.Context, driver, dsn string, cfg Config) 
 	switch driver {
 	case SQLiteBackend:
 		leaderElect = false
-		backend, err = sqlite.New(ctx, dsn)
+		backend, err = sqlite.New(ctx, dsn, cfg.ConnectionPoolConfig)
 	case DQLiteBackend:
-		backend, err = dqlite.New(ctx, dsn)
+		backend, err = dqlite.New(ctx, dsn, cfg.ConnectionPoolConfig)
 	case PostgresBackend:
-		backend, err = pgsql.New(ctx, dsn, cfg.Config)
+		backend, err = pgsql.New(ctx, dsn, cfg.Config, cfg.ConnectionPoolConfig)
 	case MySQLBackend:
-		backend, err = mysql.New(ctx, dsn, cfg.Config)
+		backend, err = mysql.New(ctx, dsn, cfg.Config, cfg.ConnectionPoolConfig)
 	default:
 		return false, nil, fmt.Errorf("storage backend is not defined")
 	}


### PR DESCRIPTION
This PR should solve the constant error messages (as described here: https://github.com/rancher/k3s/issues/1459) when using a small DB instance, e.g. db.t2.micro PostgresQL on AWS, which only can handle up to ~80 connections. This especially happens when listing all pods/workloads of the System project. I think it will just occur at any page which lists a lot of k3s resources.

The error messages also surfaced in the k3s journal logs:

```
ERRO[2020-05-28T10:17:52.444132093Z] error while range on /registry/configmaps/kube-system/cert-manager-cainjector-leader-election-core : pq: sorry, too many clients already
ERRO[2020-05-28T10:17:52.444589524Z] error while range on /registry/configmaps/kube-system/cert-manager-cainjector-leader-election : pq: sorry, too many clients already
E0528 10:17:52.452075   25763 status.go:71] apiserver received an error that is not an metav1.Status: &status.statusError{Code:2, Message:"pq: sorry, too many clients already", Details:[]*any.Any(nil), XXX_NoUnkeyedLiteral:struct {}{}, XXX_unrecognized:[]uint8(nil), XXX_sizecache:0}
```

# Solution

My PR makes connection pooling, which is currently not configured at all by kine, adjustable.

I will also mention this in the linked issue, so this can get picked up by k3s as well. Ideally, `k3s server` should expose command line flags for its server, which would look something like this in production:

| Flag                                  | Default        | Description                                                                                                                     |
|:--------------------------------------|:---------------|:--------------------------------------------------------------------------------------------------------------------------------|
| `--datastore-max-idle-connections`    | `2`            | Maximum number of idle connections used by datastore. If num <= 0, then no connections are retained                             |
| `--datastore-max-open-connections`    | `0`(unlimited) | Maximum number of idle connections used by datastore. If num <= 0, then there is no limit                                       |
| `--datastore-connection-max-lifetime` | `0s`           | Maximum amount of time a connection may be reused. Defined as a parsable string, e.g., 1s, 2500ms, and 1h30m are all accepted values |

*Note*: The default values are actually chosen to reflect the current behavior. `sql.DB.maxIdle` in `database/sql` is defaulted to 2. `sql.DB.maxLifetime` is never set explicitly in `database/sql`, so gets set to 0 when the struct gets created. Same is true for `sql.DB.maxOpen`.

This way, we could use 

```bash

k3s server --datastore-max-idle-connections 10 --datastore-max-open-connections 80 datastore-connection-max-lifetime 10s
```

I also imagine that using environment variables would be quite nice

```sh

K3S_DATASTORE_MAX_IDLE_CONNECTIONS=10 K3S_DATASTORE_MAX_OPEN_CONNECTIONS=80 K3S_DATASTORE_CONNECTION_MAX_LIFETIME=10s k3s server
```

I compiled it into the k3s executable and tested it with various settings (important was to limit the `--datastore-max-open-connections` setting, as with small DBs this is the bottleneck) and I could not reproduce any more of those mentioned errors in the rancher UI.

Let me know, if the PR is good or if it needs adjustments :)

I think, in most cases, this won't even be an issue, if you have a DB which can handle lots of connections. Otherwise, most of the time reusing idle connections can really help keeping memory usage at the DB lower and also allows small-sized DBs to be used by k3s/kine.

Cheers! 🎉 