### PR TITLE
Fix bad check in compact query

### DIFF
--- a/pkg/drivers/mysql/mysql.go
+++ b/pkg/drivers/mysql/mysql.go
@@ -74,6 +74,7 @@ func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoo
 			SELECT kp.prev_revision AS id
 			FROM kine AS kp
 			WHERE
+				kp.name != 'compact_rev_key' AND
 				kp.prev_revision != 0 AND
 				kp.id <= ?
 			UNION
@@ -83,9 +84,7 @@ func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoo
 				kd.deleted != 0 AND
 				kd.id <= ?
 		) AS ks
-		ON
-			kv.id = ks.id AND
-			kv.name != 'compact_rev_key'`
+		ON kv.id = ks.id`
 	dialect.TranslateErr = func(err error) error {
 		if err, ok := err.(*mysql.MySQLError); ok && err.Number == 1062 {
 			return server.ErrKeyExists

--- a/pkg/drivers/pgsql/pgsql.go
+++ b/pkg/drivers/pgsql/pgsql.go
@@ -64,6 +64,7 @@ func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoo
 			SELECT kp.prev_revision AS id
 			FROM kine AS kp
 			WHERE
+				kp.name != 'compact_rev_key' AND
 				kp.prev_revision != 0 AND
 				kp.id <= $1
 			UNION
@@ -73,9 +74,7 @@ func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoo
 				kd.deleted != 0 AND
 				kd.id <= $2
 		) AS ks
-		WHERE
-			kv.id = ks.id AND
-			kv.name != 'compact_rev_key'`
+		WHERE kv.id = ks.id`
 	dialect.TranslateErr = func(err error) error {
 		if err, ok := err.(*pq.Error); ok && err.Code == "23505" {
 			return server.ErrKeyExists

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -64,11 +64,11 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string, connPool
 	dialect.CompactSQL = `
 		DELETE FROM kine AS kv
 		WHERE
-			kv.name != 'compact_rev_key' AND
 			kv.id IN (
 				SELECT kp.prev_revision AS id
 				FROM kine AS kp
 				WHERE
+					kp.name != 'compact_rev_key' AND
 					kp.prev_revision != 0 AND
 					kp.id <= ?
 				UNION


### PR DESCRIPTION
* Fix issue where compact_rev_key was protected from deletion, instead
  of the row it points to. Honestly we should have stored the
  compact_rev marker in the value instead of the prev_revision
  column. (#61)

Test:
1. Run kine for k3s with external DB: `k3s --debug server --datastore=mysql://X`
1. Wait for compaction message to appear in log output - something like `level=debug msg="COMPACT deleted 0 rows from 3 revisions in 2.484763ms - compacted to 3/1745"`
1. Stop k3s+kine
1. Run query: `SELECT id, name FROM kine WHERE name = "/registry/health";`
1. Run query: `UPDATE kine SET prev_revision = 1 WHERE name = 'compact_rev_key';` - use the ID from the previous step instead of `1` if it was different.
1. Start k3s; wait for compaction message to appear in log output
1. Run query: `SELECT id, name FROM kine WHERE name = "/registry/health"`
1. Confirm that /registry/health entry still present with the same ID

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>